### PR TITLE
Add include-cache plugin and install bundle in CI

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:

--- a/_config.yml
+++ b/_config.yml
@@ -32,10 +32,8 @@ domain: pt-ki.github.io
 # theme: minima
 plugins:
   - jekyll-feed
-  - jekyll-include-cache # required by minimal-mistakes theme
-
-gems:
   - jekyll-remote-theme
+  - jekyll-include-cache
 
 remote_theme: "mmistakes/minimal-mistakes@4.27.3"
 


### PR DESCRIPTION
## Summary
- Load jekyll-feed, jekyll-remote-theme, and jekyll-include-cache via plugins block
- Run `bundle install` during GitHub Pages build to ensure required gems are installed

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc53f500c8320a776365838dcbb06