### PR TITLE
Specify Ruby 3.1 for GitHub Pages workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: '3.1'
           bundler-cache: true
       - name: Install dependencies
         run: bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## Summary
- set ruby-version to 3.1 in GitHub Pages deploy workflow

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bfcccafc288320b763ccecef9ef842