### PR TITLE
Add pre-commit configuration with linting and build check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
-Gemfile.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+  - repo: https://github.com/markdownlint/markdownlint
+    rev: v0.12.0
+    hooks:
+      - id: markdownlint
+  - repo: local
+    hooks:
+      - id: jekyll-build
+        name: jekyll build
+        entry: bundle exec jekyll build --trace
+        language: system
+        pass_filenames: false
+      - id: htmlproofer
+        name: htmlproofer
+        entry: bundle exec htmlproofer ./_site --check-html
+        language: system
+        pass_filenames: false

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,10 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
 end
 
+group :development, :test do
+  gem "html-proofer", "~> 5.0"
+end
+
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 platforms :mingw, :x64_mingw, :mswin, :jruby do

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # pt-ki.github.io
+
+This repository contains the source for the pt-ki GitHub Pages site.
+
+## Development
+
+Install Ruby dependencies and run the site locally:
+
+```bash
+bundle install
+bundle exec jekyll serve
+```
+
+## Pre-commit hooks
+
+Install and run pre-commit to lint and test the site before committing.
+The hooks will run common checks, build the site, and verify the
+generated HTML with [html-proofer](https://github.com/gjtorikian/html-proofer):
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+```


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` running common hooks, markdown linting, a Jekyll build, and HTML link checks with html-proofer
- document pre-commit usage in the README and stop ignoring `Gemfile.lock`
- include `html-proofer` in the Gemfile for local link validation

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `pre-commit run --all-files` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe55164d4832090f71bcd971a3f5c