### PR TITLE
Add pre-commit GitHub Actions workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,19 @@
+name: pre-commit
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+      - name: Install gems
+        run: bundle install --jobs 4 --retry 3
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files


### PR DESCRIPTION
## Summary
- run pre-commit hooks in CI

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 'Forbidden')*
- `pre-commit run --all-files` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68c049dd1d8c83209c107dc635fe2584